### PR TITLE
MB-39263: Move iterateChildren/RunObserveChildren to v2 api metakv

### DIFF
--- a/service_manager.go
+++ b/service_manager.go
@@ -722,16 +722,16 @@ func NewTokenMapStream() *TokenMapStream {
 	cancel := make(chan struct{})
 	ch := make(chan *TokenMap)
 
-	cb := func(path string, value []byte, rev interface{}) error {
-		if path != TokensKey {
+	cb := func(kve metakv.KVEntry) error {
+		if kve.Path != TokensKey {
 			return nil
 		}
 
 		tokens := &TokenMap{}
-		err := json.Unmarshal(value, tokens)
+		err := json.Unmarshal(kve.Value, tokens)
 		if err != nil {
 			log.Fatalf("Failed to unmarshal token map: %s\n%s",
-				err.Error(), string(value))
+				err.Error(), string(kve.Value))
 		}
 
 		select {
@@ -742,7 +742,7 @@ func NewTokenMapStream() *TokenMapStream {
 		return nil
 	}
 
-	go metakv.RunObserveChildren(ServiceDir, cb, cancel)
+	go metakv.RunObserveChildrenV2(ServiceDir, cb, cancel)
 
 	return &TokenMapStream{
 		C:      ch,


### PR DESCRIPTION
As part of a multi-stage process to move both of these api's to the V2
version, we are first changing all of these api's to the v2 version,
at which point we will duplicate it, without the v2 label, and then
eventually drop the v2 label in all services and finally remove the
duplicate in metakv.

Change-Id: I444cac602fde8be91b627902a63c22bd9de6a9b4